### PR TITLE
Refactor - pass golint and some amendments

### DIFF
--- a/gobundle/main.go
+++ b/gobundle/main.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	USAGE = `usage: {{.Name}} <path> [<path> ...]
+	// Usage contains usage information
+	Usage = `usage: {{.Name}} <path> [<path> ...]
 
 This utility and library can be used to compile static files into a binary.
 
@@ -50,17 +51,20 @@ possibly in conjunction with other flags that modify the bundle behavior:
 
 Flags:
 `
-	HEADER_TEMPLATE = `package {{ .Package }}
+	// HeaderTemplate contains the main template output.
+	HeaderTemplate = `package {{ .Package }}
 
 import (
     "github.com/alecthomas/gobundle"
 )
 
 var {{ .Bundle | ToTitle }}Bundle = gobundle.NewBuilder("{{ .Bundle }}"){{if .Compressed}}.Compressed(){{ if .RetainUncompressed }}.RetainUncompressed(){{ end }}{{ if .UncompressOnInit }}.UncompressOnInit(){{ end }}{{end}}`
-	FILE_TEMPLATE = `.Add(
+	// FileTemplate contains the file template output.
+	FileTemplate = `.Add(
     "{{ .Name }}", {{ .Content }},
 )`
-	FOOTER_TEMPLATE = `.Build()
+	// FooterTemplate contains the footer template output.
+	FooterTemplate = `.Build()
 `
 )
 
@@ -76,12 +80,14 @@ var (
 	encodeAsBytesFlag      = flag.BoolP("encode_as_bytes", "b", false, "whether to encode as bytes or the default, escaped strings")
 
 	funcMap = map[string]interface{}{"ToTitle": strings.Title}
-	usage   = template.Must(template.New("usage").Parse(USAGE))
-	header  = template.Must(template.New("header").Funcs(funcMap).Parse(HEADER_TEMPLATE))
-	file    = template.Must(template.New("file").Parse(FILE_TEMPLATE))
-	footer  = template.Must(template.New("footer").Parse(FOOTER_TEMPLATE))
+	usage   = template.Must(template.New("usage").Parse(Usage))
+	header  = template.Must(template.New("header").Funcs(funcMap).Parse(HeaderTemplate))
+	file    = template.Must(template.New("file").Parse(FileTemplate))
+	footer  = template.Must(template.New("footer").Parse(FooterTemplate))
 )
 
+// BundleContext contains contextual information around a
+// bundle.
 type BundleContext struct {
 	Package            string
 	Bundle             string
@@ -90,16 +96,19 @@ type BundleContext struct {
 	UncompressOnInit   bool
 }
 
+// FileContext contains contextual information around a file.
 type FileContext struct {
 	Name    string
-	Id      int
 	Content string
 }
 
+// BufferCloser encapsulates a buffer.
 type BufferCloser struct {
 	bytes.Buffer
 }
 
+// Close represents a close operation.
+// TODO - is this needed?
 func (b *BufferCloser) Close() error {
 	return nil
 }

--- a/gobundle/main.go
+++ b/gobundle/main.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"compress/zlib"
 	"fmt"
-	flag "github.com/ogier/pflag"
 	"io"
 	"os"
 	"path"
@@ -25,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	flag "github.com/ogier/pflag"
 )
 
 const (
@@ -55,7 +56,7 @@ import (
     "github.com/alecthomas/gobundle"
 )
 
-var {{ .Bundle | ToTitle }}Bundle *gobundle.Bundle = gobundle.NewBuilder("{{ .Bundle }}"){{if .Compressed}}.Compressed(){{ if .RetainUncompressed }}.RetainUncompressed(){{ end }}{{ if .UncompressOnInit }}.UncompressOnInit(){{ end }}{{end}}`
+var {{ .Bundle | ToTitle }}Bundle = gobundle.NewBuilder("{{ .Bundle }}"){{if .Compressed}}.Compressed(){{ if .RetainUncompressed }}.RetainUncompressed(){{ end }}{{ if .UncompressOnInit }}.UncompressOnInit(){{ end }}{{end}}`
 	FILE_TEMPLATE = `.Add(
     "{{ .Name }}", {{ .Content }},
 )`


### PR DESCRIPTION
I have added comments to all exported functions, methods and structs so the code passes golint, essentially I went down this trail as bundle.go failed to pass the linter in my own application.

Also made some minor changes:

1. Dropped the ID field from FileContext as it's not used anywhere.
2. Converted constants to camel case.
3. No need to define the data type in the variable assignment in the main template.

Hope this helps, was also thinking of adding some tests for this by creating a fixtures file, creating a bundle from it, and querying the bundle. What do you think?